### PR TITLE
fix: 게이트웨이 라우팅 설정 수정

### DIFF
--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -1,22 +1,30 @@
 server:
   port: 8000
+
 spring:
   config:
-    import: application-secret.yml  # 시크릿 키 숨기기
+    import: application-secret.yml
   application:
     name: gateway-server
   cloud:
     gateway:
       routes:
-        - id: user-management  # 이 라우트의 식별자 (아무 이름이나 가능)
-          uri: lb://USER-MANAGEMENT # 라우팅 대상 (Eureka에 등록된 서비스 이름)
-          predicates: # 어떤 요청을 이 라우트로 보낼지 정의
-            - Path=/api/user-management/** # 이 경로로 들어오는 요청만 처리함
-          filters:  # 실제로 라우팅할 때 요청을 어떻게 가공할지 정의
-            - RewritePath=/api/user-management/(?<segment>.*), /api/users/$\{segment}
+        - id: user-management-users
+          uri: lb://USER-MANAGEMENT
+          predicates:
+            - Path=/api/user-management/users/**
+          filters:
+            - RewritePath=/api/user-management/users/(?<segment>.*), /api/users/${segment}
+
+        - id: user-management-auth
+          uri: lb://USER-MANAGEMENT
+          predicates:
+            - Path=/api/user-management/auth/**
+          filters:
+            - RewritePath=/api/user-management/auth/(?<segment>.*), /auth/${segment}
 
         - id: blog-service
-          uri: http://BLOG-SERVICE  # Blog Service 직접 연결
+          uri: lb://BLOG-SERVICE  # Eureka에 등록된 서비스 이름일 경우 lb://
           predicates:
             - Path=/api/blog-service/**
           filters:

--- a/user-service/src/main/java/com/playblog/userservice/auth/dto/LoginRequestDto.java
+++ b/user-service/src/main/java/com/playblog/userservice/auth/dto/LoginRequestDto.java
@@ -1,14 +1,17 @@
 package com.playblog.userservice.auth.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @Builder
-@RequiredArgsConstructor
+@NoArgsConstructor
+@AllArgsConstructor
 public class LoginRequestDto {
-  private final String emailId;
-  private final String password;
-  private final String deviceId;
+  private String emailId;
+  private String password;
+  private String deviceId;
 }

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -2,6 +2,8 @@ server:
   port: 0
 
 spring:
+  config:
+    import: application-secret.yml
   application:
     name: USER-MANAGEMENT
   datasource:
@@ -32,12 +34,6 @@ eureka:
     fetch-registry: true
     service-url:
       defaultZone: http://localhost:8761/eureka
-jwt:
-  secret: LH9QZL8upsPBfuDY+Dkb1kT9DZIIUSuA2u4O6Lfi3mkEfeWtETpVTcR/8SMZdJWn/xNTuCQBE6rBvDXgnVmscQ==
-  expiration: 3600000 # 60분
-  refresh-expiration: 604800000 # 7일
-
-
 
 
 


### PR DESCRIPTION
- 회원가입 경로: http://localhost:8000/api/user-management/users/register
- 로그인 경로: http://localhost:8000/api/user-management/auth/login
- 같은 사용자에 대해 다른 디바이스로 로그인 시 다른 리프레시 토큰을 발급하므로, 로그인 시 deviceId를 함께 보내야 정상 동작