### PR TITLE
feat: 댓글/공감 시스템 Post 연동 및 연쇄 삭제 구현

### DIFF
--- a/blog-service/src/main/java/com/playblog/blogservice/comment/controller/CommentController.java
+++ b/blog-service/src/main/java/com/playblog/blogservice/comment/controller/CommentController.java
@@ -4,6 +4,8 @@ import com.playblog.blogservice.comment.dto.CommentRequest;
 import com.playblog.blogservice.comment.dto.CommentResponse;
 import com.playblog.blogservice.comment.dto.CommentsResponse;
 import com.playblog.blogservice.comment.service.CommentService;
+import com.playblog.blogservice.post.entity.Post;
+import com.playblog.blogservice.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,6 +20,7 @@ import java.util.Map;
 public class CommentController {
 
     private final CommentService commentService;
+    private final PostRepository postRepository;
 
     /**
      * 댓글 작성
@@ -38,12 +41,15 @@ public class CommentController {
     }
 
     /**
-     * 댓글 목록 조회
+     * 댓글 목록 조회 - post(게시글)에서 작성자 id 가져오기
      */
     @GetMapping("/posts/{postId}/comments")
     public ResponseEntity<CommentsResponse> getComments(@PathVariable Long postId, @RequestHeader(value = "X-User-Id", defaultValue = "0") Long requestUserId) {
 
-        Long postAuthorId = 1L; // TODO: Post Service에서 게시글 작성자 ID 가져오기
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시글을 찾을 수 없습니다."));
+
+        Long postAuthorId = post.getUser()!=null?post.getUser().getId():null;
 
         CommentsResponse response = commentService.getCommentsByPostId(postId, requestUserId, postAuthorId);
 

--- a/blog-service/src/main/java/com/playblog/blogservice/comment/entity/Comment.java
+++ b/blog-service/src/main/java/com/playblog/blogservice/comment/entity/Comment.java
@@ -1,8 +1,11 @@
 package com.playblog.blogservice.comment.entity;
 
+import com.playblog.blogservice.post.entity.Post;
 import com.playblog.blogservice.user.User;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -21,8 +24,10 @@ public class Comment {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // 댓글 기본 키, 자동 증가
 
-    @Column(name = "post_id", nullable = false)
-    private Long postId; // 게시글 id
+    @ManyToOne(fetch = FetchType.LAZY) //하나의 게시물의 여러개의 댓글 작성 가능
+    @JoinColumn(name = "post_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Post post; // 게시글 id
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -47,8 +52,8 @@ public class Comment {
     private LocalDateTime createdAt;
 
     @Builder
-    public Comment(Long postId, User author, String content, Boolean isSecret) {
-        this.postId = postId;
+    public Comment(Post post, User author, String content, Boolean isSecret) {
+        this.post = post;
         this.author = author;
         this.content = content;
         this.isSecret = isSecret != null ? isSecret : false; // null 체크

--- a/blog-service/src/main/java/com/playblog/blogservice/comment/repository/CommentRepository.java
+++ b/blog-service/src/main/java/com/playblog/blogservice/comment/repository/CommentRepository.java
@@ -12,13 +12,11 @@ import java.util.List;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     // 게시글의 댓글 목록 조회 (삭제되지 않은 것만)
-    List<Comment> findByPostIdAndIsDeletedFalseOrderByCreatedAtAsc(Long postId);
+    List<Comment> findByPost_IdAndIsDeletedFalseOrderByCreatedAtAsc(Long postId);
 
     // 게시글의 댓글 수 조회 (삭제되지 않은 것만)
-    long countByPostIdAndIsDeletedFalse(Long postId);
+    long countByPost_IdAndIsDeletedFalse(Long postId);
 
     // 댓글이 존재하고 삭제되지 않았는지 확인
     boolean existsByIdAndIsDeletedFalse(Long commentId);
-
-    // 게시글의 최근 댓글 N개 조회
 }

--- a/blog-service/src/main/java/com/playblog/blogservice/comment/repository/CommentRepository.java
+++ b/blog-service/src/main/java/com/playblog/blogservice/comment/repository/CommentRepository.java
@@ -2,8 +2,6 @@ package com.playblog.blogservice.comment.repository;
 
 import com.playblog.blogservice.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -16,7 +14,4 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     // 게시글의 댓글 수 조회 (삭제되지 않은 것만)
     long countByPost_IdAndIsDeletedFalse(Long postId);
-
-    // 댓글이 존재하고 삭제되지 않았는지 확인
-    boolean existsByIdAndIsDeletedFalse(Long commentId);
 }

--- a/blog-service/src/main/java/com/playblog/blogservice/common/jwt/JwtTokenProvider.java
+++ b/blog-service/src/main/java/com/playblog/blogservice/common/jwt/JwtTokenProvider.java
@@ -1,127 +1,127 @@
-package com.playblog.blogservice.common.jwt;
-
-import io.jsonwebtoken.*;
-import io.jsonwebtoken.io.Decoders;
-import io.jsonwebtoken.security.Keys;
-import jakarta.annotation.PostConstruct;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.stereotype.Component;
-
-import javax.crypto.SecretKey;
-import java.util.Date;
-
-@Component
-public class JwtTokenProvider {
-
-  @Value("${jwt.secret}")
-  private String jwtSecret;
-
-  @Value("${jwt.expiration}")
-  private long accessTokenExpiration;
-
-  @Value("${jwt.refresh-expiration}")
-  private long refreshTokenExpiration;
-  // JWT 생성 시 서명할 키
-  private SecretKey secretKey;
-
-  @PostConstruct
-  public void init() {
-    // 빈 초기화 후, BASE64인코딩 문자열을 디코딩하여 SecretKey로 변환
-    byte[] keyBytes = Decoders.BASE64.decode(jwtSecret);
-    secretKey = Keys.hmacShaKeyFor(keyBytes); // JWT 서명에 사용
-  }
-
-  // access token 생성 메소드 (claim에 userId 추가)
-  public String createAccessToken(String emailId, String role, Long userId) {
-    Date now = new Date();
-    Date expiryDate = new Date(now.getTime() + accessTokenExpiration);
-    return Jwts.builder()
-        .subject(emailId)                 // sub: jwt에서 사용자 식별자 역할, 인증 주체
-        .claim("role", role)               // 사용자 권한 정보
-        .claim("userId", userId)           // 사용자 ID
-        .issuedAt(now)                     // iat: 발급 시간
-        .expiration(expiryDate)            // exp: 만료 시간
-        .signWith(secretKey)               // 서명 키
-        .compact();                        // 최종적으로 JWT 문자열로 생성
-  }
-
-  // refresh token 생성 메소드 (claim에 userId 추가)
-  public String createRefreshToken(String emailId, String role, Long userId, String deviceId) {
-    Date now = new Date();
-    Date expiryDate = new Date(now.getTime() + refreshTokenExpiration);
-    return Jwts.builder()
-        .subject(emailId)
-        .claim("role", role)
-        .claim("userId", userId)
-        .claim("deviceId", deviceId)
-        .issuedAt(now)
-        .expiration(expiryDate)
-        .signWith(secretKey)
-        .compact();
-  }
-
-
-    public boolean validateToken(String token) {
-        try {
-            // 서명 검증 + 만료 기간 포함해서 파싱 (문제가 없으면 true 반환)
-            Jwts.parser()
-                .setSigningKey(secretKey)
-                .build()
-                .parseClaimsJws(token);
-            return true;
-
-        } catch (SecurityException | MalformedJwtException e) {
-            // JWT 서명이 올바르지 않거나, 형식 자체가 잘못된 경우
-            // 예: 토큰 구조가 3부분으로 되어 있지 않음, 서명 위조
-            throw new BadCredentialsException("Invalid JWT Token", e);
-
-        } catch (ExpiredJwtException e) {
-            // 토큰이 유효기간을 초과한 경우
-            throw new BadCredentialsException("Expired JWT Token", e);
-
-        } catch (UnsupportedJwtException e) {
-            // 지원되지 않는 형식의 JWT인 경우
-            // 예: 압축 알고리즘이 이상하거나, 일반적으로 파싱이 불가능한 포맷
-            throw new BadCredentialsException("Unsupported JWT Token", e);
-
-        } catch (IllegalArgumentException e) {
-            // 토큰이 null이거나 비어 있는 경우
-            throw new BadCredentialsException("JWT Token claims empty", e);
-        }
-    }
-
-    // 토큰에서 emailId(subject) 추출
-  public String getEmailIdFromJWT(String token) {
-    Claims claims = Jwts.parser()
-        .verifyWith(secretKey)
-        .build()
-        .parseSignedClaims(token)
-        .getBody();
-    return claims.getSubject();
-  }
-
-  public Long getUserIdFromJWT(String token) {
-    Claims claims = Jwts.parser()
-        .verifyWith(secretKey)
-        .build()
-        .parseSignedClaims(token)
-        .getBody();
-    return claims.get("userId", Long.class);
-  }
-
-    public String getRoleFromJWT(String token) {
-        Claims claims = Jwts.parser()
-            .setSigningKey(secretKey)
-            .build()
-            .parseClaimsJws(token)
-            .getBody();
-        return claims.get("role", String.class);
-    }
-
-
-  public long getRefreshExpiration() {
-    return refreshTokenExpiration;
-  }
-
-}
+//package com.playblog.blogservice.common.jwt;
+//
+//import io.jsonwebtoken.*;
+//import io.jsonwebtoken.io.Decoders;
+//import io.jsonwebtoken.security.Keys;
+//import jakarta.annotation.PostConstruct;
+//import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.security.authentication.BadCredentialsException;
+//import org.springframework.stereotype.Component;
+//
+//import javax.crypto.SecretKey;
+//import java.util.Date;
+//
+//@Component
+//public class JwtTokenProvider {
+//
+//  @Value("${jwt.secret}")
+//  private String jwtSecret;
+//
+//  @Value("${jwt.expiration}")
+//  private long accessTokenExpiration;
+//
+//  @Value("${jwt.refresh-expiration}")
+//  private long refreshTokenExpiration;
+//  // JWT 생성 시 서명할 키
+//  private SecretKey secretKey;
+//
+//  @PostConstruct
+//  public void init() {
+//    // 빈 초기화 후, BASE64인코딩 문자열을 디코딩하여 SecretKey로 변환
+//    byte[] keyBytes = Decoders.BASE64.decode(jwtSecret);
+//    secretKey = Keys.hmacShaKeyFor(keyBytes); // JWT 서명에 사용
+//  }
+//
+//  // access token 생성 메소드 (claim에 userId 추가)
+//  public String createAccessToken(String emailId, String role, Long userId) {
+//    Date now = new Date();
+//    Date expiryDate = new Date(now.getTime() + accessTokenExpiration);
+//    return Jwts.builder()
+//        .subject(emailId)                 // sub: jwt에서 사용자 식별자 역할, 인증 주체
+//        .claim("role", role)               // 사용자 권한 정보
+//        .claim("userId", userId)           // 사용자 ID
+//        .issuedAt(now)                     // iat: 발급 시간
+//        .expiration(expiryDate)            // exp: 만료 시간
+//        .signWith(secretKey)               // 서명 키
+//        .compact();                        // 최종적으로 JWT 문자열로 생성
+//  }
+//
+//  // refresh token 생성 메소드 (claim에 userId 추가)
+//  public String createRefreshToken(String emailId, String role, Long userId, String deviceId) {
+//    Date now = new Date();
+//    Date expiryDate = new Date(now.getTime() + refreshTokenExpiration);
+//    return Jwts.builder()
+//        .subject(emailId)
+//        .claim("role", role)
+//        .claim("userId", userId)
+//        .claim("deviceId", deviceId)
+//        .issuedAt(now)
+//        .expiration(expiryDate)
+//        .signWith(secretKey)
+//        .compact();
+//  }
+//
+//
+//    public boolean validateToken(String token) {
+//        try {
+//            // 서명 검증 + 만료 기간 포함해서 파싱 (문제가 없으면 true 반환)
+//            Jwts.parser()
+//                .setSigningKey(secretKey)
+//                .build()
+//                .parseClaimsJws(token);
+//            return true;
+//
+//        } catch (SecurityException | MalformedJwtException e) {
+//            // JWT 서명이 올바르지 않거나, 형식 자체가 잘못된 경우
+//            // 예: 토큰 구조가 3부분으로 되어 있지 않음, 서명 위조
+//            throw new BadCredentialsException("Invalid JWT Token", e);
+//
+//        } catch (ExpiredJwtException e) {
+//            // 토큰이 유효기간을 초과한 경우
+//            throw new BadCredentialsException("Expired JWT Token", e);
+//
+//        } catch (UnsupportedJwtException e) {
+//            // 지원되지 않는 형식의 JWT인 경우
+//            // 예: 압축 알고리즘이 이상하거나, 일반적으로 파싱이 불가능한 포맷
+//            throw new BadCredentialsException("Unsupported JWT Token", e);
+//
+//        } catch (IllegalArgumentException e) {
+//            // 토큰이 null이거나 비어 있는 경우
+//            throw new BadCredentialsException("JWT Token claims empty", e);
+//        }
+//    }
+//
+//    // 토큰에서 emailId(subject) 추출
+//  public String getEmailIdFromJWT(String token) {
+//    Claims claims = Jwts.parser()
+//        .verifyWith(secretKey)
+//        .build()
+//        .parseSignedClaims(token)
+//        .getBody();
+//    return claims.getSubject();
+//  }
+//
+//  public Long getUserIdFromJWT(String token) {
+//    Claims claims = Jwts.parser()
+//        .verifyWith(secretKey)
+//        .build()
+//        .parseSignedClaims(token)
+//        .getBody();
+//    return claims.get("userId", Long.class);
+//  }
+//
+//    public String getRoleFromJWT(String token) {
+//        Claims claims = Jwts.parser()
+//            .setSigningKey(secretKey)
+//            .build()
+//            .parseClaimsJws(token)
+//            .getBody();
+//        return claims.get("role", String.class);
+//    }
+//
+//
+//  public long getRefreshExpiration() {
+//    return refreshTokenExpiration;
+//  }
+//
+//}

--- a/blog-service/src/main/java/com/playblog/blogservice/post/service/PostService.java
+++ b/blog-service/src/main/java/com/playblog/blogservice/post/service/PostService.java
@@ -9,7 +9,7 @@ import com.playblog.blogservice.post.entity.PostPolicy;
 import com.playblog.blogservice.post.repository.TestLikeRepository;
 import com.playblog.blogservice.post.repository.PostPolicyRepository;
 import com.playblog.blogservice.post.repository.PostRepository;
-import com.playblog.blogservice.search.repository.UserRepository;
+import com.playblog.blogservice.user.UserRepository;
 import com.playblog.blogservice.user.User;
 import com.playblog.blogservice.userInfo.UserInfo;
 import jakarta.persistence.EntityNotFoundException;

--- a/blog-service/src/main/java/com/playblog/blogservice/postlike/entity/PostLike.java
+++ b/blog-service/src/main/java/com/playblog/blogservice/postlike/entity/PostLike.java
@@ -1,17 +1,20 @@
 package com.playblog.blogservice.postlike.entity;
 
+import com.playblog.blogservice.post.entity.Post;
 import com.playblog.blogservice.user.User;
 import jakarta.persistence.*;
         import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
-@Entity
+@Entity(name = "BlogPostLike")
 @Table(name = "post_likes")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -22,8 +25,10 @@ public class PostLike {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "post_id", nullable = false)
-    private Long postId; // Post 참조용
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Post post;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -34,8 +39,8 @@ public class PostLike {
     private LocalDateTime createdAt;
 
     @Builder
-    public PostLike(Long postId, User user) {
-        this.postId = postId;
+    public PostLike(Post post, User user) {
+        this.post = post;
         this.user = user;
     }
 

--- a/blog-service/src/main/java/com/playblog/blogservice/postlike/repository/PostLikeRepository.java
+++ b/blog-service/src/main/java/com/playblog/blogservice/postlike/repository/PostLikeRepository.java
@@ -11,17 +11,17 @@ import java.util.Optional;
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
     // 게시글에 공감 확인
-    Optional<PostLike> findByPostIdAndUser_Id(Long postId, Long userId);
+    Optional<PostLike> findByPost_IdAndUser_Id(Long postId, Long userId);
 
     // 게시글에 공감 여부 확인
     boolean existsByPostIdAndUser_Id(Long postId, Long userId);
 
     // 게시글의 공감 수
-    long countByPostId(Long postId);
+    long countByPost_Id(Long postId);
 
     // 게시글에 공감한 사용자 목록 (최신순)
-    List<PostLike> findByPostIdOrderByCreatedAtDesc(Long postId);
+    List<PostLike> findByPost_IdOrderByCreatedAtDesc(Long postId);
 
     // 게시글 공감 삭제
-    void deleteByPostIdAndUser_Id(Long postId, Long userId);
+    void deleteByPost_IdAndUser_Id(Long postId, Long userId);
 }

--- a/blog-service/src/main/java/com/playblog/blogservice/postlike/repository/PostLikeRepository.java
+++ b/blog-service/src/main/java/com/playblog/blogservice/postlike/repository/PostLikeRepository.java
@@ -13,9 +13,6 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     // 게시글에 공감 확인
     Optional<PostLike> findByPost_IdAndUser_Id(Long postId, Long userId);
 
-    // 게시글에 공감 여부 확인
-    boolean existsByPostIdAndUser_Id(Long postId, Long userId);
-
     // 게시글의 공감 수
     long countByPost_Id(Long postId);
 

--- a/blog-service/src/main/java/com/playblog/blogservice/postlike/service/PostLikeService.java
+++ b/blog-service/src/main/java/com/playblog/blogservice/postlike/service/PostLikeService.java
@@ -1,6 +1,8 @@
 package com.playblog.blogservice.postlike.service;
 
-import com.playblog.blogservice.common.repository.UserRepository;
+import com.playblog.blogservice.post.entity.Post;
+import com.playblog.blogservice.post.repository.PostRepository;
+import com.playblog.blogservice.user.UserRepository;
 import com.playblog.blogservice.postlike.dto.PostLikeResponse;
 import com.playblog.blogservice.postlike.dto.PostLikeUserResponse;
 import com.playblog.blogservice.postlike.dto.PostLikesResponse;
@@ -22,49 +24,61 @@ import java.util.stream.Collectors;
 public class PostLikeService {
 
     private final UserRepository userRepository;
+    private final PostRepository postRepository;
     private final PostLikeRepository postLikeRepository;
 
     // 1. 게시글 공감 토글 (있으면 취소, 없으면 추가)
     @Transactional
     public PostLikeResponse togglePostLike(Long postId, Long userId) {
-        Optional<PostLike> existingLike = postLikeRepository.findByPostIdAndUser_Id(postId, userId);
+        // 1. 게시글 존재 확인
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+
+        // 2. 공감 허용 여부 확인
+        if (post.getAllowLike() != null && !post.getAllowLike()) {
+            throw new IllegalArgumentException("이 게시글은 공감을 허용하지 않습니다.");
+        }
+
+        // 3. 사용자 존재 확인
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        // 4. 공감 여부 확인
+        Optional<PostLike> existingLike = postLikeRepository.findByPost_IdAndUser_Id(postId, userId);
 
         if (existingLike.isPresent()) {
-            // 이미 공감했으면 공감 취소
-            postLikeRepository.deleteByPostIdAndUser_Id(postId, userId);
-
-            long likeCount = postLikeRepository.countByPostId(postId);
-            return new PostLikeResponse(false, likeCount);
+            // 공감 취소
+            postLikeRepository.deleteByPost_IdAndUser_Id(postId, userId);
+            long newCount = postLikeRepository.countByPost_Id(postId);
+            return new PostLikeResponse(false, newCount);  // ✅ DTO 사용
         } else {
-            // 공감하지 않았으면 공감 추가
-            User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
-
-            PostLike newLike = PostLike.builder()
-                    .postId(postId)
+            // 공감 추가
+            PostLike postLike = PostLike.builder()
+                    .post(post)
                     .user(user)
                     .build();
-            postLikeRepository.save(newLike);
 
-            long likeCount = postLikeRepository.countByPostId(postId);
-            return new PostLikeResponse(true, likeCount);
+            postLikeRepository.save(postLike);
+            long newCount = postLikeRepository.countByPost_Id(postId);
+            return new PostLikeResponse(true, newCount);   // ✅ DTO 사용
         }
     }
 
     // 2. 게시글의 공감 수 조회
     public long getPostLikeCount(Long postId) {
-        return postLikeRepository.countByPostId(postId);
+        return postLikeRepository.countByPost_Id(postId);
     }
 
     // 3. 게시글 공감 여부 확인
     public PostLikeResponse isPostLikedByUser(Long postId, Long userId) {
-        boolean isLiked = postLikeRepository.existsByPostIdAndUser_Id(postId, userId);
-        long likeCount = postLikeRepository.countByPostId(postId);
+        boolean isLiked = postLikeRepository.findByPost_IdAndUser_Id(postId, userId).isPresent();
+        long likeCount = postLikeRepository.countByPost_Id(postId);
         return new PostLikeResponse(isLiked, likeCount);
     }
 
     // 4. 게시글에 공감한 사용자 목록 조회
     public PostLikesResponse getPostLikeUsers(Long postId) {
-        List<PostLike> postLikes = postLikeRepository.findByPostIdOrderByCreatedAtDesc(postId);
+        List<PostLike> postLikes = postLikeRepository.findByPost_IdOrderByCreatedAtDesc(postId);
 
         // PostLike들을 PostLikeUserResponse로 변환
         List<PostLikeUserResponse> likedUsers = postLikes.stream()

--- a/blog-service/src/main/java/com/playblog/blogservice/user/UserRepository.java
+++ b/blog-service/src/main/java/com/playblog/blogservice/user/UserRepository.java
@@ -1,6 +1,5 @@
-package com.playblog.blogservice.common.repository;
+package com.playblog.blogservice.user;
 
-import com.playblog.blogservice.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {


### PR DESCRIPTION
## 🎯 작업 내용
- Comment/PostLike 엔티티에서 Long postId → Post post 매핑으로 변경
- 게시글 삭제 시 댓글/공감 연쇄 삭제 구현 (@OnDelete CASCADE)
- JPA 자동 쿼리 적용 (findByPost_IdAndIsDeletedFalse...)
- Post 정책 기반 권한 체크 (allowComment, allowLike)
- JWT 인증 완전 통합 및 실제 사용자 정보 연동

## ✅ 테스트 완료
- 댓글 CRUD 기능
- 게시글/댓글 공감 기능  
- Post 정책에 따른 접근 제어
- MSA Gateway 연동

## 🔗 관련 API
- `POST /posts/{postId}/comments` - 댓글 작성
- `GET /posts/{postId}/comments` - 댓글 목록
- `POST /posts/{postId}/like` - 게시글 공감
- `GET /posts/{postId}/comments/count` - 댓글 수 (검색팀용)