### PR TITLE
프론트에서 User생성 후 매핑되는 UserInfo 생성할 수 있게 로직 변경

### DIFF
--- a/blog-service/src/main/java/com/playblog/blogservice/user/User.java
+++ b/blog-service/src/main/java/com/playblog/blogservice/user/User.java
@@ -30,6 +30,9 @@ public class User {
   private long id;
 
   @Column(nullable = false)
+  private String emailId;
+
+  @Column(nullable = false)
   private String password;
 
   @Enumerated(EnumType.STRING)

--- a/blog-service/src/main/java/com/playblog/blogservice/userInfo/UserInfo.java
+++ b/blog-service/src/main/java/com/playblog/blogservice/userInfo/UserInfo.java
@@ -25,18 +25,10 @@ public class UserInfo {
   @OnDelete(action = OnDeleteAction.CASCADE)  // 외래키 관계 필드에만 적용
   private User user;
 
-  String blogTitle;
-  String nickname;
-  String blogId;
+  String blogTitle; // 블로그명
+  String nickname; // 별명
+  String blogId; // 블로그 아이디 (= 로그인 이메일 아이디)
   String profileIntro; // 프로필 소개글
   String profileImageUrl; // 프로필 이미지 URL
-
-
-  // Neighbor은 단방향 참조 예정..
- @OneToMany(mappedBy = "fromUserInfo")
-  private List<Neighbor> followingList;
-
-  @OneToMany(mappedBy = "toUserInfo")
-  private List<Neighbor> followerList;
 
 }

--- a/blog-service/src/main/java/com/playblog/blogservice/userInfo/UserInfoService.java
+++ b/blog-service/src/main/java/com/playblog/blogservice/userInfo/UserInfoService.java
@@ -1,5 +1,7 @@
 package com.playblog.blogservice.userInfo;
 
+import com.playblog.blogservice.user.User;
+import com.playblog.blogservice.user.UserRepository;
 import com.playblog.blogservice.userInfo.dto.UserInfoRequest;
 import com.playblog.blogservice.userInfo.dto.UserInfoResponse;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserInfoService {
 
   private final UserInfoRepository userInfoRepository;
+  private final UserRepository userRepository;
 
   @Transactional(readOnly = true)
   public UserInfoResponse getUserInfo(Long userId) {
@@ -26,11 +29,14 @@ public class UserInfoService {
       return new UserInfoResponse(userInfoRepository.findById(userId).get());
     }
     UserInfo info = new UserInfo();
-    info.setId(userId);
+    User user = userRepository.findById(userId).orElseThrow();
+    String emailId = user.getEmailId();
+    info.setUser(user);
+    info.setBlogTitle(emailId+"님의블로그");
     info.setNickname("");
-    info.setBlogTitle("");
-    info.setBlogId("");
+    info.setBlogId(emailId);
     info.setProfileIntro("");
+    info.setProfileImageUrl("");
     return new UserInfoResponse(userInfoRepository.save(info));
   }
 
@@ -43,6 +49,7 @@ public class UserInfoService {
     userInfo.setBlogTitle(dto.getBlogTitle());
     userInfo.setBlogId(dto.getBlogId());
     userInfo.setProfileIntro(dto.getProfileIntro());
+    userInfo.setProfileImageUrl("");
 
     return new UserInfoResponse(userInfo);
   }

--- a/blog-service/src/main/java/com/playblog/blogservice/userInfo/dto/UserInfoRequest.java
+++ b/blog-service/src/main/java/com/playblog/blogservice/userInfo/dto/UserInfoRequest.java
@@ -10,4 +10,5 @@ public class UserInfoRequest {
   private String nickname;
   private String blogId;
   private String profileIntro;
+  private String profileImgeUrl;
 }

--- a/blog-service/src/main/java/com/playblog/blogservice/userInfo/dto/UserInfoResponse.java
+++ b/blog-service/src/main/java/com/playblog/blogservice/userInfo/dto/UserInfoResponse.java
@@ -1,22 +1,25 @@
 package com.playblog.blogservice.userInfo.dto;
 
+import com.playblog.blogservice.user.User;
 import com.playblog.blogservice.userInfo.UserInfo;
 import lombok.Getter;
 
 @Getter
 public class UserInfoResponse {
-  private Long id;
+  private User user;
   private String blogTitle;
   private String nickname;
   private String blogId;
   private String profileIntro;
+  private String profileImgeUrl;
 
   public UserInfoResponse(UserInfo userInfo) {
-    this.id = userInfo.getId();
+    this.user = userInfo.getUser();
     this.blogTitle = userInfo.getBlogTitle();
     this.nickname = userInfo.getNickname();
     this.blogId = userInfo.getBlogId();
     this.profileIntro = userInfo.getProfileIntro();
+    this.profileImgeUrl = userInfo.getProfileImageUrl();
   }
 
 

--- a/blog-service/src/main/resources/application.yml
+++ b/blog-service/src/main/resources/application.yml
@@ -2,6 +2,10 @@ server:
   port: 0
 #  port: ${SERVER_PORT:8081}   # env SERVER_PORT가 있으면 그 값을, 없으면 8081을 기본으로
 spring:
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
   config:
     import: application-secret.yml  # 비밀 설정 파일을 가져옴
   application:

--- a/user-service/src/main/java/com/playblog/userservice/user/UserController.java
+++ b/user-service/src/main/java/com/playblog/userservice/user/UserController.java
@@ -3,6 +3,8 @@ package com.playblog.userservice.user;
 import com.playblog.userservice.common.exception.DuplicateEmailException;
 import com.playblog.userservice.common.response.EmailCheckResponse;
 import com.playblog.userservice.user.dto.UserRegisterRequestDto;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,12 +32,18 @@ public class UserController {
 
 
   @PostMapping("/register")
-  public ResponseEntity<String> registerUser(@Valid @RequestBody UserRegisterRequestDto requestDto) {
+  public ResponseEntity<Map<String, Object>> registerUser(@Valid @RequestBody UserRegisterRequestDto requestDto) {
     try {
-      userService.registerUser(requestDto);
-      return ResponseEntity.status(HttpStatus.CREATED).body("회원가입 성공");
+      Long registeredId = userService.registerUser(requestDto);
+      Map<String, Object> responseBody = new HashMap<>();
+      responseBody.put("message", "회원가입 성공");
+      responseBody.put("userId", registeredId);
+
+      return ResponseEntity.status(HttpStatus.CREATED).body(responseBody);
     } catch (DuplicateEmailException e) {
-      return ResponseEntity.status(HttpStatus.CONFLICT).body("이미 존재하는 이메일입니다.");
+      Map<String, Object> responseBody = new HashMap<>();
+      responseBody.put("message", "이미 존재하는 이메일입니다.");
+      return ResponseEntity.status(HttpStatus.CONFLICT).body(responseBody);
     }
   }
 

--- a/user-service/src/main/java/com/playblog/userservice/user/UserService.java
+++ b/user-service/src/main/java/com/playblog/userservice/user/UserService.java
@@ -22,7 +22,7 @@ public class UserService {
 
 
   @Transactional
-  public void registerUser(UserRegisterRequestDto requestDto) {
+  public Long registerUser(UserRegisterRequestDto requestDto) {
     System.out.println(requestDto);
     if (isEmailDuplicate(requestDto.getEmailId())) {
       throw new DuplicateEmailException();
@@ -33,5 +33,6 @@ public class UserService {
 
     user.setPassword(encodedPassword);  // 암호화된 비밀번호 세팅
     userRepository.save(user);
+    return user.getId();
   }
 }


### PR DESCRIPTION
- 사진 업로드 최대 크기 10MB 지정으로 application.yml 수정
- User등록 시, 성공메시지와 pk 반환하도록 로직 수정
- blog-service의 User필드에 누락된 emailId 추가
- UserInfo 엔터티의 followingList, followerList 필드 삭제
- UserInfoRequest와 UserInfoResponse 객체에 누락된 profileImgUrl 추가