### PR TITLE
refactor: 블로그정보 조회 시, 사용자의 id(pk) 반환하도록 수정

### DIFF
--- a/blog-service/src/main/java/com/playblog/blogservice/userInfo/dto/UserInfoResponse.java
+++ b/blog-service/src/main/java/com/playblog/blogservice/userInfo/dto/UserInfoResponse.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 public class UserInfoResponse {
-  private User user;
+  private Long userId;
   private String blogTitle;
   private String nickname;
   private String blogId;
@@ -14,7 +14,7 @@ public class UserInfoResponse {
   private String profileImgeUrl;
 
   public UserInfoResponse(UserInfo userInfo) {
-    this.user = userInfo.getUser();
+    this.userId = userInfo.getUser().getId();
     this.blogTitle = userInfo.getBlogTitle();
     this.nickname = userInfo.getNickname();
     this.blogId = userInfo.getBlogId();


### PR DESCRIPTION
- UserInfoResponse의 User user -> Long userId로 수정