### PR TITLE
 fix: user-service의 테스트 코드 통과 실패 오류 해결

### DIFF
--- a/user-service/src/test/java/com/playblog/userservice/auth/service/AuthServiceTest.java
+++ b/user-service/src/test/java/com/playblog/userservice/auth/service/AuthServiceTest.java
@@ -63,15 +63,6 @@ class AuthServiceTest {
   void setUp() {
     MockitoAnnotations.openMocks(this);
 
-    // 실제 JwtTokenProvider 생성 (비밀키와 만료시간은 테스트용 값 입력)
-    jwtTokenProvider = new JwtTokenProvider();
-    ReflectionTestUtils.setField(jwtTokenProvider, "jwtSecret",
-        "LH9QZL8upsPBfuDY+Dkb1kT9DZIIUSuA2u4O6Lfi3mkEfeWtETpVTcR/8SMZdJWn/xNTuCQBE6rBvDXgnVmscQ==");  // 테스트용 비밀키
-    ReflectionTestUtils.setField(jwtTokenProvider, "accessTokenExpiration", 3600000L);    // 1시간
-    ReflectionTestUtils.setField(jwtTokenProvider, "refreshTokenExpiration", 86400000L);  // 24시간
-
-    jwtTokenProvider.init();
-
     // authService에 실제 JwtTokenProvider 주입 (기존 mock 대신)
     ReflectionTestUtils.setField(authService, "jwtTokenProvider", jwtTokenProvider);
   }

--- a/user-service/src/test/java/com/playblog/userservice/user/UserServiceTest.java
+++ b/user-service/src/test/java/com/playblog/userservice/user/UserServiceTest.java
@@ -38,9 +38,10 @@ class UserServiceTest {
     // given
     String rawPassword = "password123";
     UserRegisterRequestDto dto = new UserRegisterRequestDto("newuser@example.com", rawPassword);
-
-    // when
-    userService.registerUser(dto);
+    // 1. 해당 사용사자 없으면 회원가입한다.
+    if (!userRepository.existsByEmailId("newuser@example.com")) {
+      userService.registerUser(dto);
+    }
 
     // then
     User savedUser = userRepository.findByEmailId(dto.getEmailId())


### PR DESCRIPTION
 - 이미 있는 사용자로 회원가입 못하게 로직 수정
 - 테스트코드에 포함되어 있는 암호화 키 값 삭제